### PR TITLE
feature/sql_schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -31,11 +31,11 @@ CREATE TABLE topics (
 -- Podcast table
 CREATE TABLE podcast (
     podcast_id SERIAL PRIMARY KEY,
-    podcast_name VARCHAR(255) NOT NULL,
+    podcast_name TEXT NOT NULL,
     publish_date TIMESTAMP,
     language_id INTEGER REFERENCES language(language_id) ON DELETE SET NULL,
     uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    podcast_url VARCHAR(500) NOT NULL UNIQUE
+    podcast_url TEXT NOT NULL UNIQUE
 );
 
 -- Episode table


### PR DESCRIPTION
# Description

This PR implements a complete 3NF-compliant PostgreSQL schema for the podcast analysis pipeline. It creates 7 tables: `Podcast`, `Episode`, `Speakers`, `Topics`, `language`, and two junction tables (`episode_speakers`, `episode_topics`) to handle many-to-many relationships. The schema includes foreign key constraints with cascade deletes, indexes on frequently queried fields, and fields to support AI features. To use, run `psql -U postgres -d podcast_analysis -f schema.sql`.

## Issues Closed
- Closes #9 